### PR TITLE
Fix starting application of Linux

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,4 +89,8 @@ Currently not tested on Mac, but you can try the instructions from Julius. They 
 
 (Feel free to add a pull request to add additional Mac instructions here.)
 
+## Contributing
+
+Please use `clang-format-15` before submitting changes by using `./clang-format.sh` on Linux.
+
 ![Alt](https://repobeats.axiom.co/api/embed/d972b1b3da5423da758f1b4a1396177626bff54b.svg "Repobeats analytics image")

--- a/src/io/gamestate/boilerplate.cpp
+++ b/src/io/gamestate/boilerplate.cpp
@@ -586,29 +586,10 @@ static void prepare_savegame_schema(e_file_format file_format, const int file_ve
     FILEIO.push_chunk(4, false, "family_index", 0);
 }
 
-bool GamestateIO::prepare_folders(const char* path) {
-    char fpath[MAX_FILE_NAME] = {0};
-    strcpy(fpath, path);
-    char* token = strtok(fpath, "/");      // Split the path by '/'
-    char currentPath[MAX_FILE_NAME] = {0}; // Store the current path
-
-    while (token != NULL) {
-        strcat(currentPath, token); // Append the current folder to the current path
-        strcat(currentPath, "/");
-
-        // Check if the folder exists, if not create it
-        struct stat st = {0};
-        if (stat(currentPath, &st) == -1) {
-#ifdef _MSC_VER
-            mkdir(currentPath);
-#else
-            mkdir(currentPath, 0x755);
-#endif
-        }
-
-        token = strtok(NULL, "/");
-    }
-    return true;
+void GamestateIO::prepare_folders(const char* path) {
+    std::error_code err;
+    if (!std::filesystem::create_directories(path, err) && !std::filesystem::exists(path))
+        throw std::runtime_error(err.message());
 }
 
 bool GamestateIO::prepare_savegame(const char* filename_short) {

--- a/src/io/gamestate/boilerplate.h
+++ b/src/io/gamestate/boilerplate.h
@@ -12,7 +12,13 @@ const int read_file_version(const char* filename, int offset);
 
 bool write_mission(const int scenario_id);
 bool write_savegame(const char* filename_short);
-bool prepare_folders(const char* path);
+
+/**
+ * Create folders if not exists
+ * Throw exception if path not exists and can not be created
+ * @param path to be created
+ */
+void prepare_folders(const char* path);
 bool prepare_savegame(const char* filename_short);
 bool write_map(const char* filename_short);
 


### PR DESCRIPTION
Replace legacy code to fix problem with creation path on Linux.
So game can be started for selected 'family' because `/DEV_TESTING/zip/` can be created sucessfully