### PR TITLE
Stop crashing on stratup because of resources

### DIFF
--- a/src/io/dir.cpp
+++ b/src/io/dir.cpp
@@ -114,9 +114,10 @@ const char* dir_get_case_corrected_file(const char* dir, const char* filepath) {
 
     size_t dir_len = 0;
     if (dir) {
-        dir_len = strlen(dir) + 1;
+        dir_len = strlen(dir);
         strncpy(corrected_filename, dir, 2 * MAX_FILE_NAME - 1);
-        corrected_filename[dir_len - 1] = '/';
+        if (corrected_filename[dir_len - 1] != '/')
+            corrected_filename[dir_len] = '/';
     } else {
         dir = ".";
     }

--- a/src/io/imagepaks/imagepak.cpp
+++ b/src/io/imagepaks/imagepak.cpp
@@ -346,7 +346,7 @@ bool imagepak::load_pak(const char* pak_name, int starting_index) {
 
     // construct proper filepaths
     name = pak_name;
-    bstring512 filename_full("data/", pak_name);
+    bstring512 filename_full("Data/", pak_name);
 
     // split in .555 and .sg3 filename strings
     bstring512 filename_555(filename_full, ".555");


### PR DESCRIPTION
Interesting that I have different folder name... and faced these issues recently (before it was working fine).
BTW, now it is not crashing, but no background images.